### PR TITLE
fix: fixed assemply member photos not loading

### DIFF
--- a/sites/msb/next.config.mjs
+++ b/sites/msb/next.config.mjs
@@ -25,6 +25,7 @@ const nextConfig = {
     remotePatterns: [
       new URL('https://d1159zutbdy4l.cloudfront.net/**'),
       new URL('https://images.matsu.gov/**'),
+      new URL('https://msb-cms-documents.s3.us-west-2.amazonaws.com/**'),
     ],
   },
 };

--- a/sites/widgets/next.config.ts
+++ b/sites/widgets/next.config.ts
@@ -19,6 +19,7 @@ const nextConfig: NextConfig = {
     remotePatterns: [
       new URL('https://d1159zutbdy4l.cloudfront.net/**'),
       new URL('https://images.matsu.gov/**'),
+      new URL('https://msb-cms-documents.s3.us-west-2.amazonaws.com/**'),
     ],
   },
 };


### PR DESCRIPTION
This pull request updates the `remotePatterns` configuration in two `next.config` files to include a new URL pattern for loading resources from an additional domain.

Configuration updates:

* [`sites/msb/next.config.mjs`](diffhunk://#diff-901bfc5606f55f70424d8315b8655c87f9f7f90cd4a8ab5b3ec14fa61e4df05cR28): Added `https://msb-cms-documents.s3.us-west-2.amazonaws.com/**` to the `remotePatterns` array to allow loading resources from this domain.
* [`sites/widgets/next.config.ts`](diffhunk://#diff-32c04402aad2b1c3ab51b00b723a37f0ed1e853cb5188c5fb49d95d6e3924bf6R22): Added `https://msb-cms-documents.s3.us-west-2.amazonaws.com/**` to the `remotePatterns` array to allow loading resources from this domain.