### PR TITLE
fix: internal links with no target no longer cause server errors

### DIFF
--- a/packages/ui/src/components/Tooltip/Tooltip.tsx
+++ b/packages/ui/src/components/Tooltip/Tooltip.tsx
@@ -12,7 +12,7 @@ export function Tooltip({
   anchor?: 'top' | 'bottom' | 'left' | 'right';
 }) {
   return (
-    <div className="relative inline-block group">
+    <span className="relative inline-block group">
       {children}
       <div
         className={clsx(
@@ -40,6 +40,6 @@ export function Tooltip({
       >
         {content}
       </div>
-    </div>
+    </span>
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,7 +134,7 @@ importers:
         version: 1.12.16(graphql@16.11.0)(typescript@5.8.3)
       '@apollo/client-integration-nextjs':
         specifier: ^0.12.2
-        version: 0.12.2(@apollo/client@3.13.8(@types/react@19.1.6)(graphql-ws@6.0.5(graphql@16.11.0)(ws@8.18.2))(graphql@16.11.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@types/react@19.1.6)(graphql@16.11.0)(next@15.3.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 0.12.2(@apollo/client@3.13.8(@types/react@19.1.6)(graphql-ws@6.0.5(graphql@16.11.0)(ws@8.18.2))(graphql@16.11.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@types/react@19.1.6)(graphql@16.11.0)(next@15.3.3(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@graphql-codegen/cli':
         specifier: ^5.0.6
         version: 5.0.6(@parcel/watcher@2.5.1)(@types/node@22.15.29)(graphql@16.11.0)(typescript@5.8.3)
@@ -286,7 +286,7 @@ importers:
     dependencies:
       '@apollo/client-integration-nextjs':
         specifier: ^0.12.2
-        version: 0.12.2(@apollo/client@3.13.8(@types/react@19.1.6)(graphql-ws@6.0.5(graphql@16.11.0)(ws@8.18.2))(graphql@16.11.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@types/react@19.1.6)(graphql@16.11.0)(next@15.3.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 0.12.2(@apollo/client@3.13.8(@types/react@19.1.6)(graphql-ws@6.0.5(graphql@16.11.0)(ws@8.18.2))(graphql@16.11.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@types/react@19.1.6)(graphql@16.11.0)(next@15.3.3(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@matsugov/ui':
         specifier: workspace:^
         version: link:../../packages/ui
@@ -319,10 +319,10 @@ importers:
         version: 7.15.8(algoliasearch@5.20.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react-instantsearch-nextjs:
         specifier: ^0.4.9
-        version: 0.4.9(next@15.3.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-instantsearch@7.15.8(algoliasearch@5.20.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
+        version: 0.4.9(next@15.3.3(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-instantsearch@7.15.8(algoliasearch@5.20.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
       react-instantsearch-router-nextjs:
         specifier: ^7.15.8
-        version: 7.15.8(algoliasearch@5.20.0)(next@15.3.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
+        version: 7.15.8(algoliasearch@5.20.0)(next@15.3.3(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
       react-loading-skeleton:
         specifier: ^3.5.0
         version: 3.5.0(react@19.1.0)
@@ -6230,7 +6230,7 @@ snapshots:
 
   '@antfu/utils@8.1.1': {}
 
-  '@apollo/client-integration-nextjs@0.12.2(@apollo/client@3.13.8(@types/react@19.1.6)(graphql-ws@6.0.5(graphql@16.11.0)(ws@8.18.2))(graphql@16.11.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@types/react@19.1.6)(graphql@16.11.0)(next@15.3.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@apollo/client-integration-nextjs@0.12.2(@apollo/client@3.13.8(@types/react@19.1.6)(graphql-ws@6.0.5(graphql@16.11.0)(ws@8.18.2))(graphql@16.11.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@types/react@19.1.6)(graphql@16.11.0)(next@15.3.3(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@apollo/client': 3.13.8(@types/react@19.1.6)(graphql-ws@6.0.5(graphql@16.11.0)(ws@8.18.2))(graphql@16.11.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@apollo/client-react-streaming': 0.12.2(@apollo/client@3.13.8(@types/react@19.1.6)(graphql-ws@6.0.5(graphql@16.11.0)(ws@8.18.2))(graphql@16.11.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@types/react@19.1.6)(graphql@16.11.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -11378,12 +11378,12 @@ snapshots:
       react: 19.1.0
       use-sync-external-store: 1.5.0(react@19.1.0)
 
-  react-instantsearch-nextjs@0.4.9(next@15.3.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-instantsearch@7.15.8(algoliasearch@5.20.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)):
+  react-instantsearch-nextjs@0.4.9(next@15.3.3(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-instantsearch@7.15.8(algoliasearch@5.20.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)):
     dependencies:
       next: 15.3.3(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react-instantsearch: 7.15.8(algoliasearch@5.20.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
 
-  react-instantsearch-router-nextjs@7.15.8(algoliasearch@5.20.0)(next@15.3.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0):
+  react-instantsearch-router-nextjs@7.15.8(algoliasearch@5.20.0)(next@15.3.3(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0):
     dependencies:
       instantsearch.js: 4.78.3(algoliasearch@5.20.0)
       next: 15.3.3(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)

--- a/sites/msb/components/server/MarkdownRenderer/MarkdownRenderer.tsx
+++ b/sites/msb/components/server/MarkdownRenderer/MarkdownRenderer.tsx
@@ -15,18 +15,22 @@ export function MarkdownRenderer(props: { children: string }) {
       components={{
         a: (props: AnchorHTMLAttributes<HTMLAnchorElement>) => {
           const isExternal = props.href?.startsWith('http');
-          return (
-            <Link
-              href={props.href as string}
-              className={`usa-link ${isExternal ? 'usa-link--external' : ''}`}
-              target={isExternal ? '_blank' : '_self'}
-              referrerPolicy={
-                isExternal ? 'no-referrer' : 'strict-origin-when-cross-origin'
-              }
-            >
-              {props.children}
-            </Link>
-          );
+          const isEmail = props.href?.startsWith('mailto:');
+
+          if (!isEmail)
+            return (
+              <Link
+                href={props.href as string}
+                className={`usa-link ${isExternal ? 'usa-link--external' : ''}`}
+                target={isExternal ? '_blank' : '_self'}
+                referrerPolicy={
+                  isExternal ? 'no-referrer' : 'strict-origin-when-cross-origin'
+                }
+              >
+                {props.children}
+              </Link>
+            );
+          else return props.children;
         },
         process: Process,
         step: Step,

--- a/sites/msb/components/server/MarkdownRenderer/components/InternalLink.tsx
+++ b/sites/msb/components/server/MarkdownRenderer/components/InternalLink.tsx
@@ -7,8 +7,8 @@ import Link from 'next/link';
 import { plural } from 'pluralize';
 import v from 'voca';
 
-function getUrl(data: GetInternalLinkDataQuery, list: string) {
-  if (data.getInternalLink) {
+function getUrl(data: GetInternalLinkDataQuery, list?: string) {
+  if (data.getInternalLink && list) {
     if ('slug' in data.getInternalLink) {
       return `/${v.slugify(plural(list))}/${data.getInternalLink.slug}`;
     }
@@ -26,48 +26,50 @@ function getUrl(data: GetInternalLinkDataQuery, list: string) {
 }
 
 export async function InternalLink(props: {
-  list: string;
-  itemID: string;
+  list?: string;
+  itemID?: string;
   children: string;
 }) {
-  const { data } = await getClient().query({
-    query: GET_INTERNAL_LINK_DATA,
-    variables: {
-      id: props.itemID,
-      list: props.list,
-    },
-  });
+  if (props.list && props.itemID) {
+    const { data, errors, error } = await getClient().query({
+      query: GET_INTERNAL_LINK_DATA,
+      variables: {
+        id: props.itemID,
+        list: props.list,
+      },
+    });
 
-  const url = getUrl(data, props.list);
+    const url = getUrl(data, props.list);
 
-  const isExternalLink =
-    !!url?.startsWith('http://') || !!url?.startsWith('https://');
+    const isExternalLink =
+      !!url?.startsWith('http://') || !!url?.startsWith('https://');
 
-  if (url)
-    return (
-      <Link
-        href={url}
-        target={isExternalLink ? '_blank' : undefined}
-        referrerPolicy="no-referrer"
-        className={clsx({
-          'line-through !text-error': url === '/not-found',
-        })}
-      >
-        {props.children}{' '}
-        {isExternalLink && (
-          <span className="icon-[mdi--external-link] -mb-0.5" />
-        )}
-      </Link>
-    );
-  else
-    return (
-      <Tooltip
-        content="Oops! Looks like this link is broken. We are working on it!"
-        className="text-center"
-      >
-        <span className="text-error line-through cursor-not-allowed">
-          {props.children} <span className="icon-[mdi--error] -mb-0.5" />
-        </span>
-      </Tooltip>
-    );
+    if (url && !errors?.length && !error)
+      return (
+        <Link
+          href={url}
+          target={isExternalLink ? '_blank' : undefined}
+          referrerPolicy="no-referrer"
+          className={clsx({
+            'line-through !text-error': url === '/not-found',
+          })}
+        >
+          {props.children}{' '}
+          {isExternalLink && (
+            <span className="icon-[mdi--external-link] -mb-0.5" />
+          )}
+        </Link>
+      );
+  }
+
+  return (
+    <Tooltip
+      content="Oops! Looks like this link is broken. We are working on it!"
+      className="text-center"
+    >
+      <span className="!text-error !line-through !cursor-not-allowed">
+        {props.children} <span className="icon-[mdi--error] -mb-0.5" />
+      </span>
+    </Tooltip>
+  );
 }


### PR DESCRIPTION
This pull request includes updates to improve the behavior and structure of tooltips, enhance Markdown rendering for email links, and make internal link handling more robust. Additionally, it updates dependencies in the `pnpm-lock.yaml` file to include `@babel/core` in relevant packages.

### Component Updates:

* **Tooltip Component (`packages/ui/src/components/Tooltip/Tooltip.tsx`)**:
  - Changed the wrapper element from `div` to `span` to better align with inline-block styling and improve semantic usage. [[1]](diffhunk://#diff-709dfe3710ff4891518367b8d12770c2d6d359a5f007a6f287d73c4f392cafb6L15-R15) [[2]](diffhunk://#diff-709dfe3710ff4891518367b8d12770c2d6d359a5f007a6f287d73c4f392cafb6L43-R43)

* **Markdown Renderer (`sites/msb/components/server/MarkdownRenderer/MarkdownRenderer.tsx`)**:
  - Disabled automatic conversion of emails to mailto links. [[1]](diffhunk://#diff-e586b959a2a0f9f3b9357f184263cfb224c242a703836592ce473f1b0e49659fR18-R20) [[2]](diffhunk://#diff-e586b959a2a0f9f3b9357f184263cfb224c242a703836592ce473f1b0e49659fR33)

* **Internal Link Component (`sites/msb/components/server/MarkdownRenderer/components/InternalLink.tsx`)**:
  - Made the `list` and `itemID` props optional and added error handling for cases where these props are missing or invalid.
  - Improved error messaging for broken links by updating the tooltip and styling of the fallback element. [[1]](diffhunk://#diff-7a88b392989f3672f9fd354a159e7284111cc3b616d3c3cddd6180e3f74c65b7L10-R11) [[2]](diffhunk://#diff-7a88b392989f3672f9fd354a159e7284111cc3b616d3c3cddd6180e3f74c65b7L29-R34) [[3]](diffhunk://#diff-7a88b392989f3672f9fd354a159e7284111cc3b616d3c3cddd6180e3f74c65b7L46-R47) [[4]](diffhunk://#diff-7a88b392989f3672f9fd354a159e7284111cc3b616d3c3cddd6180e3f74c65b7L62-R70)

### Dependency Updates:

* **`pnpm-lock.yaml`**:
  - Updated several dependencies to include `@babel/core` in the dependency chain for `@apollo/client-integration-nextjs`, `react-instantsearch-nextjs`, and `react-instantsearch-router-nextjs`. This ensures compatibility and resolves potential build issues. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL137-R137) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL289-R289) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL322-R325) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL6233-R6233) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL11381-R11386)