### PR TITLE
Fix/remark directive parsing

### DIFF
--- a/packages/sdk/apollo.config.json
+++ b/packages/sdk/apollo.config.json
@@ -2,7 +2,7 @@
   "client": {
     "service": {
       "name": "msb-cms",
-      "url": "http://localhost:3333/api/graphql"
+      "localSchemaFile": "../../../cms/apps/cms/schema.graphql"
     },
     "excludes": [
       "**/node_modules",

--- a/packages/sdk/apollo.config.json
+++ b/packages/sdk/apollo.config.json
@@ -3,6 +3,13 @@
     "service": {
       "name": "msb-cms",
       "url": "http://localhost:3333/api/graphql"
-    }
+    },
+    "excludes": [
+      "**/node_modules",
+      "**/dist",
+      "**/build",
+      "**/graphql/**/*.ts",
+      "**/__tests__"
+    ]
   }
 }

--- a/packages/ui/src/components/Tooltip/Tooltip.tsx
+++ b/packages/ui/src/components/Tooltip/Tooltip.tsx
@@ -14,10 +14,10 @@ export function Tooltip({
   return (
     <span className="relative inline-block group">
       {children}
-      <div
+      <span
         className={clsx(
           // base styles
-          'w-max max-w-3xs scale-0 opacity-0  bg-gray-900 text-white text-sm px-3 py-1 rounded shadow-md',
+          'block w-max max-w-3xs scale-0 opacity-0  bg-gray-900 text-white text-sm px-3 py-1 rounded shadow-md',
 
           // tooltip positioning
           'absolute',
@@ -39,7 +39,7 @@ export function Tooltip({
         )}
       >
         {content}
-      </div>
+      </span>
     </span>
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -344,6 +344,9 @@ importers:
       typesense-instantsearch-adapter:
         specifier: ^2.9.0
         version: 2.9.0(@babel/runtime@7.27.4)
+      unist-util-visit:
+        specifier: ^5.0.0
+        version: 5.0.0
       voca:
         specifier: ^1.4.1
         version: 1.4.1

--- a/sites/msb/app/boards/page.tsx
+++ b/sites/msb/app/boards/page.tsx
@@ -82,9 +82,10 @@ export default async function BoardsPage({
             </CardHeader>
             <CardBody>
               <ul className="list-disc list-inside">
-                {page.documents?.map((doc) => (
-                  <>
-                    {doc.file?.url && doc.title && (
+                {page.documents?.map(
+                  (doc) =>
+                    doc.file?.url &&
+                    doc.title && (
                       <li key={doc.id} className="list-disc list-inside">
                         <Link
                           href={doc.file.url}
@@ -94,9 +95,8 @@ export default async function BoardsPage({
                           {doc.title}
                         </Link>
                       </li>
-                    )}
-                  </>
-                ))}
+                    ),
+                )}
               </ul>
             </CardBody>
           </Card>

--- a/sites/msb/app/page.tsx
+++ b/sites/msb/app/page.tsx
@@ -101,9 +101,10 @@ export default async function Home() {
       <section className="flex justify-center items-center bg-base-lightest py-4 px-2">
         <div className=" max-w-[900px] w-full">
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 lg:gap-8 w-full">
-            {toolBeltItems.map((item) => (
-              <>
-                {item.url && item.title && (
+            {toolBeltItems.map(
+              (item) =>
+                item.url &&
+                item.title && (
                   <Link
                     href={item.url}
                     className="rounded-sm px-5 py-3 shadow-lg bg-white hover:bg-gray-100 text-base-darkest font-bold w-full no-underline"
@@ -116,9 +117,8 @@ export default async function Home() {
                       <span>{item.title}</span>
                     </div>
                   </Link>
-                )}
-              </>
-            ))}
+                ),
+            )}
           </div>
         </div>
       </section>

--- a/sites/msb/global.d.ts
+++ b/sites/msb/global.d.ts
@@ -1,6 +1,7 @@
 import { ComponentProps } from 'react';
-import { Process, Step } from './components/server/MarkdownRenderer/components';
+import { Process } from './components/server/MarkdownRenderer/components/Process';
 import { InternalLink } from './components/server/MarkdownRenderer/components/InternalLink';
+import { Step } from './components/server/MarkdownRenderer/components/Step';
 
 declare module 'react' {
   namespace JSX {

--- a/sites/msb/package.json
+++ b/sites/msb/package.json
@@ -30,6 +30,7 @@
     "remark-gfm": "^4.0.1",
     "swiper": "^11.2.8",
     "typesense-instantsearch-adapter": "^2.9.0",
+    "unist-util-visit": "^5.0.0",
     "voca": "^1.4.1"
   },
   "devDependencies": {

--- a/sites/msb/tsconfig.json
+++ b/sites/msb/tsconfig.json
@@ -22,7 +22,8 @@
     "./configs/**/*.ts",
     "./hooks/**/*.ts",
     "./utils/**/*.ts",
-    ".next/types/**/*.ts"
+    ".next/types/**/*.ts",
+    "./next-env.d.ts"
   ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
This pull request introduces several updates across the codebase, including configuration changes, UI enhancements, performance optimizations, and the addition of a custom Markdown plugin. Below is a summary of the most significant changes grouped by theme:

### Configuration Updates
* Updated `apollo.config.json` to replace the GraphQL service URL with a local schema file (`localSchemaFile`) and added exclusions for directories like `node_modules`, `dist`, and `__tests__` to streamline the Apollo client configuration.
* Added `unist-util-visit` as a dependency in `pnpm-lock.yaml` and `package.json` to support the new Markdown plugin. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR347-R349) [[2]](diffhunk://#diff-510d97af2bc61f2eb0df4a83ef2b09e8f453ee56fe36efdde422f044e8f2e1c5R33)
* Updated `tsconfig.json` to include `next-env.d.ts` in the `include` array for better TypeScript support.

### UI Enhancements
* Refactored the `Tooltip` component in `Tooltip.tsx` by replacing the `div` with a `span` for better semantic HTML and ensuring consistent styling. [[1]](diffhunk://#diff-709dfe3710ff4891518367b8d12770c2d6d359a5f007a6f287d73c4f392cafb6L17-R20) [[2]](diffhunk://#diff-709dfe3710ff4891518367b8d12770c2d6d359a5f007a6f287d73c4f392cafb6L42-R42)

### Performance Optimizations
* Simplified map functions in `BoardsPage` and `Home` components by removing unnecessary React fragments (`<>`) for cleaner and more efficient rendering logic. [[1]](diffhunk://#diff-ea68f12fb2b8dd22ab9a6f7166e631900f27a42e1db3b7756ed490a63fb585b7L85-R88) [[2]](diffhunk://#diff-ea68f12fb2b8dd22ab9a6f7166e631900f27a42e1db3b7756ed490a63fb585b7R98-L99) [[3]](diffhunk://#diff-95c3c5950357f2086350c9f8fa62766341a3d248684cba63734663260fcebac2L104-R107) [[4]](diffhunk://#diff-95c3c5950357f2086350c9f8fa62766341a3d248684cba63734663260fcebac2R120-L121)

### Markdown Plugin Addition
* Introduced a custom `remarkFilterUnsupportedDirectives` plugin in `MarkdownRenderer.tsx` to filter out unsupported Markdown directives, replacing them with their literal syntax. This ensures better compatibility and flexibility when rendering Markdown content.
* Enhanced the `MarkdownRenderer` component to strip `<br>` tags from the rendered content for cleaner output.